### PR TITLE
Use "Message" property of Exception

### DIFF
--- a/SQLitePCL.pretty/SQLiteException.cs
+++ b/SQLitePCL.pretty/SQLiteException.cs
@@ -84,6 +84,6 @@ namespace SQLitePCL.pretty
 
         /// <inheritdoc/>
         public override string ToString() =>
-            $"{ErrorCode}: {Message}\r\n{base.ToString()}";
+            $"{ErrorCode}: {base.ToString()}";
     }
 }

--- a/SQLitePCL.pretty/SQLiteException.cs
+++ b/SQLitePCL.pretty/SQLiteException.cs
@@ -76,17 +76,14 @@ namespace SQLitePCL.pretty
         /// </summary>
         public ErrorCode ExtendedErrorCode { get; }
 
-        private readonly string errmsg;
-
-        private SQLiteException(ErrorCode errorCode, ErrorCode extendedErrorCode, string msg)
+        private SQLiteException(ErrorCode errorCode, ErrorCode extendedErrorCode, string msg) : base(msg)
         {
             this.ErrorCode = errorCode;
             this.ExtendedErrorCode = extendedErrorCode;
-            errmsg = msg;
         }
 
         /// <inheritdoc/>
         public override string ToString() =>
-            $"{ErrorCode}: {errmsg}\r\n{base.ToString()}";
+            $"{ErrorCode}: {Message}\r\n{base.ToString()}";
     }
 }


### PR DESCRIPTION
Use "Message" property of Exception class to display message. Otherwise the message is not displayed in the VS NUnit test runner 