### PR TITLE
Close the sqlite3_stmt safehandle

### DIFF
--- a/SQLitePCL.pretty/Implementation.cs
+++ b/SQLitePCL.pretty/Implementation.cs
@@ -213,6 +213,7 @@ namespace SQLitePCL.pretty
 
             db.Disposing -= dbDisposing;
             db.RemoveStatement(this);
+            stmt.Close();
         }
 
         public bool MoveNext()


### PR DESCRIPTION
By not closing the handle, the object lives until GC finalization, which is not terribly great.