### PR TITLE
use invariantculture for double parsing

### DIFF
--- a/SQLitePCL.pretty/SQLiteValue.cs
+++ b/SQLitePCL.pretty/SQLiteValue.cs
@@ -17,6 +17,7 @@
 
 using System;
 using System.Buffers.Text;
+using System.Globalization;
 using System.Text;
 using System.Text.RegularExpressions;
 
@@ -531,7 +532,7 @@ namespace SQLitePCL.pretty
             var result = stringToDoubleCast.Match(this.value);
             if (result.Success)
             {
-                if (double.TryParse(result.Value, out double parsed))
+                if (double.TryParse(result.Value, NumberStyles.Number, CultureInfo.InvariantCulture, out double parsed))
                 {
                     return parsed;
                 }


### PR DESCRIPTION
```
SQLitePCL.pretty.Tests.SQLiteValueTests.TestStringValue

Xunit.Sdk.EqualException
Assert.Equal() Failure
Expected: 123456 (rounded from 123456)
Actual:   1234,56 (rounded from 1234,56)
```